### PR TITLE
feat: implement `AnnotatedDict` return type

### DIFF
--- a/docs/guides/annotated-dicts.md
+++ b/docs/guides/annotated-dicts.md
@@ -1,0 +1,78 @@
+# AnnotatedDict: Multiple Output Handles
+
+`AnnotatedDict` is a special return type annotation that allows nodepack functions to have multiple output handles. Instead of a single "output" socket, nodes can expose individual dictionary keys as separate output connections.
+
+## Basic Usage
+
+Import `AnnotatedDict` from the schema extractor and use it with `Literal` to specify output keys:
+
+```python
+from typing import Literal
+from psynapse_backend.schema_extractor import AnnotatedDict
+
+def split_name(full_name: str) -> AnnotatedDict[Literal["first", "last"]]:
+    """Split a full name into first and last name."""
+    parts = full_name.strip().split(" ", 1)
+    return {
+        "first": parts[0],
+        "last": parts[1] if len(parts) > 1 else "",
+    }
+```
+
+This creates a node with two output handles: `first` and `last`. Downstream nodes can connect to either output independently.
+
+## How It Works
+
+1. **Schema Extraction**: When the backend loads your nodepack, it detects the `AnnotatedDict[Literal[...]]` return type and extracts the key names
+2. **Frontend Rendering**: The node displays multiple output handles on the right side, one for each key
+3. **Execution**: When the node executes, it returns a dictionary. The executor routes each key's value to the appropriate connected edges
+
+## Example: Mathematical Operations
+
+```python
+def divmod_numbers(a: float, b: float) -> AnnotatedDict[Literal["quotient", "remainder"]]:
+    """Calculate both quotient and remainder of a division."""
+    if b == 0:
+        raise ValueError("Division by zero")
+    return {
+        "quotient": a // b,
+        "remainder": a % b,
+    }
+```
+
+## Validation
+
+The executor validates that the returned dictionary contains all expected keys. If a key is missing, a `ValueError` is raised:
+
+```
+ValueError: AnnotatedDict output missing expected key 'first'. Available keys: ['name']
+```
+
+## Connecting to Downstream Nodes
+
+When connecting an `AnnotatedDict` node to another node:
+
+- Each output handle corresponds to a specific dictionary key
+- The connected downstream node receives only the value for that key (not the full dictionary)
+- Multiple downstream nodes can connect to different outputs from the same source node
+
+## Comparison with Regular Dict
+
+| Feature | `dict` return | `AnnotatedDict` return |
+|---------|---------------|------------------------|
+| Output handles | Single "output" | One per specified key |
+| Value passed | Full dictionary | Individual key values |
+| Schema | `returns: [{name: "result", type: "dict"}]` | `returns: [{name: "key1"}, {name: "key2"}, ...]` |
+
+## Best Practices
+
+1. **Use descriptive key names**: Keys become handle labels in the UI
+2. **Keep key count reasonable**: Too many outputs can clutter the node
+3. **Document the keys**: Include key descriptions in your docstring
+4. **Always return all keys**: The executor validates that all declared keys are present
+
+## Limitations
+
+- Only top-level dictionary keys are supported (no nested access like `user.name`)
+- Keys must be string literals defined at annotation time
+- The function must return a plain dictionary (not a custom dict subclass)

--- a/frontend/src/components/FunctionNode.tsx
+++ b/frontend/src/components/FunctionNode.tsx
@@ -5,6 +5,9 @@ import type { NodeData } from "../types/schema";
 const FunctionNode = ({ data, id }: NodeProps<NodeData>) => {
   const params = data.params || [];
   const edges = data.edges || [];
+  // Get returns array - default to single "output" handle for backward compatibility
+  const returns = data.returns || [{ name: "output", type: "any" }];
+  const hasMultipleOutputs = returns.length > 1;
 
   // Filter params: only show those WITHOUT default values in the node
   const paramsWithoutDefaults = useMemo(() => {
@@ -170,16 +173,75 @@ const FunctionNode = ({ data, id }: NodeProps<NodeData>) => {
           );
         })}
 
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="output"
-        style={{
-          background: "#4a90e2",
-          width: "10px",
-          height: "10px",
-        }}
-      />
+      {/* Output section for multiple outputs */}
+      {hasMultipleOutputs ? (
+        <div
+          style={{
+            marginTop: "10px",
+            borderTop: "1px solid #eee",
+            paddingTop: "8px",
+          }}
+        >
+          <div
+            style={{
+              fontSize: "10px",
+              color: "#999",
+              marginBottom: "6px",
+            }}
+          >
+            Outputs:
+          </div>
+          {returns.map((ret) => (
+            <div
+              key={ret.name}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "flex-end",
+                marginBottom: "6px",
+                position: "relative",
+                minHeight: "20px",
+                paddingRight: "8px",
+              }}
+            >
+              <span
+                style={{
+                  fontSize: "11px",
+                  color: "#666",
+                }}
+              >
+                {ret.name}
+              </span>
+              <Handle
+                type="source"
+                position={Position.Right}
+                id={ret.name}
+                style={{
+                  background: "#4a90e2",
+                  width: "10px",
+                  height: "10px",
+                  position: "absolute",
+                  right: "-5px",
+                  top: "50%",
+                  transform: "translateY(-50%)",
+                }}
+              />
+            </div>
+          ))}
+        </div>
+      ) : (
+        /* Single output - default centered position */
+        <Handle
+          type="source"
+          position={Position.Right}
+          id={returns[0]?.name || "output"}
+          style={{
+            background: "#4a90e2",
+            width: "10px",
+            height: "10px",
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/components/PsynapseEditor.tsx
+++ b/frontend/src/components/PsynapseEditor.tsx
@@ -154,6 +154,7 @@ const PsynapseEditorInner = () => {
           label: schema.name,
           functionName: schema.name,
           params: schema.params,
+          returns: schema.returns,
           docstring: schema.docstring,
           onChange: handleNodeDataChange,
           edges: [], // Will be updated with actual edges

--- a/frontend/src/types/schema.ts
+++ b/frontend/src/types/schema.ts
@@ -24,6 +24,7 @@ export interface NodeData {
   label: string;
   functionName?: string;
   params?: ParamSchema[];
+  returns?: ReturnSchema[];
   docstring?: string;
   executionStatus?: "executing" | "completed" | "error";
   variableName?: string;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,7 @@ nav:
     - Architecture: guides/architecture.md
     - Progress Nodes: guides/progress-nodes.md
     - Streaming Nodes: guides/stream-nodes.md
+    - Annotated Dictionaries: guides/annotated-dicts.md
   - Examples:
     - LLM Examples: examples/llm.md
   - API Reference:

--- a/nodepacks/basic/ops.py
+++ b/nodepacks/basic/ops.py
@@ -1,4 +1,7 @@
 import math
+from typing import Literal
+
+from psynapse_backend.schema_extractor import AnnotatedDict
 
 
 def add(a: float, b: float) -> float:
@@ -151,3 +154,47 @@ def at_index(object: list | dict, index: int | str) -> any:
     if isinstance(object, list):
         return object[int(index)]
     return object[index]
+
+
+def split_name(full_name: str) -> AnnotatedDict[Literal["first", "last"]]:
+    """
+    Split a full name into first and last name components.
+
+    This function demonstrates the AnnotatedDict feature which creates
+    multiple output handles for the node - one for 'first' and one for 'last'.
+
+    Args:
+        full_name: The full name to split (e.g., "John Doe")
+
+    Returns:
+        A dictionary with 'first' and 'last' keys containing the name parts
+    """
+    parts = full_name.strip().split(" ", 1)
+    return {
+        "first": parts[0],
+        "last": parts[1] if len(parts) > 1 else "",
+    }
+
+
+def divmod_numbers(
+    a: float, b: float
+) -> AnnotatedDict[Literal["quotient", "remainder"]]:
+    """
+    Calculate both the quotient and remainder of a division operation.
+
+    This function demonstrates the AnnotatedDict feature for mathematical operations,
+    creating separate output handles for 'quotient' and 'remainder'.
+
+    Args:
+        a: The dividend (number to be divided)
+        b: The divisor (number to divide by)
+
+    Returns:
+        A dictionary with 'quotient' and 'remainder' keys
+    """
+    if b == 0:
+        raise ValueError("Division by zero")
+    return {
+        "quotient": a // b,
+        "remainder": a % b,
+    }


### PR DESCRIPTION
`AnnotatedDict` is a special return type annotation that allows nodepack functions to have multiple output handles. Instead of a single "output" socket, nodes can expose individual dictionary keys as separate output connections.

<img width="1728" height="999" alt="Screenshot 2026-01-22 at 1 24 45 PM" src="https://github.com/user-attachments/assets/c04411c5-c06a-44e5-9374-dd1f70c41099" />
